### PR TITLE
backupId can be null

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -14,9 +14,11 @@ class Config extends BaseConfig
 
     public const STORAGE_BACKEND_GCS = 'gcs';
 
-    public function getBackupId(): string
+    public function getBackupId(): ?string
     {
-        return $this->getStringValue(['parameters', 'backupId'], '');
+        /** @var ?string $val */
+        $val = $this->getValue(['parameters', 'backupId'], '');
+        return $val;
     }
 
     public function getStorageBackendType(): string

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -30,6 +30,33 @@ class ConfigTest extends TestCase
         Assert::assertEquals($expectedStorageBackendType, $config->getStorageBackendType());
     }
 
+    public function testBackupId(): void
+    {
+        $config = new Config([
+            'action' => 'run',
+            'parameters' => [
+                'backupId' => '123456',
+            ],
+            'image_parameters' => [
+                'storageBackendType' => Config::STORAGE_BACKEND_S3,
+            ],
+        ], new ConfigDefinition());
+
+        Assert::assertEquals('123456', $config->getBackupId());
+
+        $config = new Config([
+            'action' => 'run',
+            'parameters' => [
+                'backupId' => null,
+            ],
+            'image_parameters' => [
+                'storageBackendType' => Config::STORAGE_BACKEND_S3,
+            ],
+        ], new ConfigDefinition());
+
+        Assert::assertEquals('', $config->getBackupId());
+    }
+
     /** @dataProvider invalidConfigDataProvider */
     public function testInvalidConfig(array $configArray, string $expectedExceptionMessage): void
     {


### PR DESCRIPTION
backupId ještě může být null

```
TypeError:Keboola\Component\Config\BaseConfig::getStringValue(): Return value must be of type string, null returned {"errFile":"/code/vendor/keboola/php-component/src/Config/BaseConfig.php","errLine":85,"errCode":0,"errTrace":"#0 /code/src/Config/Config.php(19): Keboola\\Component\\Config\\BaseConfig->getStringValue(Array, '')\n#1 /code/src/Application.php(89): Keboola\\App\\ProjectBackup\\Config\\Config->getBackupId()\n#2 /code/src/Component.php(28): Keboola\\App\\ProjectBackup\\Application->generateReadCredentials()\n#3 /code/vendor/keboola/php-component/src/BaseComponent.php(207): Keboola\\App\\ProjectBackup\\Component->generateReadCredentialsAction()\n#4 /code/src/run.php(14): Keboola\\Component\\BaseComponent->execute()\n#5 {main}","errPrevious":""} 
```