### PR TITLE
Azure - check if container exists

### DIFF
--- a/src/Storages/AzureBlobStorage.php
+++ b/src/Storages/AzureBlobStorage.php
@@ -41,7 +41,14 @@ class AzureBlobStorage implements IStorage
             $this->config->getAccountKey(),
         );
         $client = ClientFactory::createClientFromConnectionString($connectionString);
-        $client->createContainer($path);
+        try {
+            $client->getContainerMetadata($path);
+        } catch (ServiceException $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+            $client->createContainer($path);
+        }
 
         $sasHelper = new BlobSharedAccessSignatureHelper(
             $this->config->getAccountName(),


### PR DESCRIPTION
blbost kvůli které nešla migrace z Azure stacku... pokud container už existuje (a existuje ze zálohy) tak se to zaseklo na timeoutu sync akce a neběželo dál... 

teoreticky bychom to createContainer mohli smazat, ale nechal jsem to tam no