### PR TITLE
fix: add Azure Storage patch for PHP 8.x NULL parameter deprecation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ## Composer - deps always cached unless changed
 # First copy only composer files
 COPY composer.* /code/
+COPY patches /code/patches
 # Download dependencies, but don't run scripts or init autoloaders as the app is missing
 RUN composer install $COMPOSER_FLAGS --no-scripts --no-autoloader
 # copy rest of the app

--- a/composer.json
+++ b/composer.json
@@ -57,9 +57,9 @@
     },
     "extra": {
         "patches": {
-            "microsoft/azure-storage-common": [
-                "patches/microsoft-azure-storage-common-src-common-internal-servicerestproxy-php.patch"
-            ]
+            "microsoft/azure-storage-common": {
+                "Fix NULL parameter deprecation in PHP 8.x for ServiceRestProxy": "patches/microsoft-azure-storage-common-src-common-internal-servicerestproxy-php.patch"
+            }
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "microsoft/azure-storage-blob": "^1.5"
     },
     "require-dev": {
+        "cweagans/composer-patches": "^1.7",
         "keboola/coding-standard": "^15.0",
         "keboola/datadir-tests": "^5.6",
         "keboola/php-temp": "^2.0",
@@ -50,7 +51,15 @@
         "sort-packages": true,
         "optimize-autoloader": true,
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "cweagans/composer-patches": true
+        }
+    },
+    "extra": {
+        "patches": {
+            "microsoft/azure-storage-common": [
+                "patches/microsoft-azure-storage-common-src-common-internal-servicerestproxy-php.patch"
+            ]
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f5e22600c56b816d29659303af019861",
+    "content-hash": "fde0b3c9e84b3f5eeaaefd1b1876319a",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4275,6 +4275,54 @@
     ],
     "packages-dev": [
         {
+            "name": "cweagans/composer-patches",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
+            },
+            "time": "2022-12-20T22:53:13+00:00"
+        },
+        {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v1.0.0",
             "source": {
@@ -6489,5 +6537,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fde0b3c9e84b3f5eeaaefd1b1876319a",
+    "content-hash": "976fa12c20aaef794fb436ceeb1bf544",
     "packages": [
         {
             "name": "aws/aws-crt-php",

--- a/patches/microsoft-azure-storage-common-src-common-internal-servicerestproxy-php.patch
+++ b/patches/microsoft-azure-storage-common-src-common-internal-servicerestproxy-php.patch
@@ -1,0 +1,11 @@
+--- /dev/null
++++ ../src/Common/Internal/ServiceRestProxy.php
+@@ -77,7 +77,7 @@
+         array $options = []
+     ) {
+         $primaryUri   = Utilities::appendDelimiter($primaryUri, '/');
+-        $secondaryUri = Utilities::appendDelimiter($secondaryUri, '/');
++        $secondaryUri = Utilities::appendDelimiter($secondaryUri ?? '', '/');
+ 
+         $dataSerializer = new XmlSerializer();
+         parent::__construct($dataSerializer);


### PR DESCRIPTION
## Summary

Adds a patch for the `microsoft/azure-storage-common` library to fix a PHP 8.x deprecation error that occurs when backing up table data from Azure-based stacks.

**Problem:** When running `app-project-migrate` with `directDataMigration: false` on an Azure source stack, the backup fails with:
```
ErrorException: substr(): Passing null to parameter #1 ($string) of type string is deprecated
```

This happens because the Azure Storage library passes NULL as the secondary URI to `ServiceRestProxy`, which eventually calls `substr(NULL, -1)`.

**Solution:** Apply the same patch that `app-project-restore` already uses - handle NULL by coalescing to empty string: `$secondaryUri ?? ''`

## Changes

- Added `cweagans/composer-patches` to `require-dev` for patch management
- Created patch file at `patches/microsoft-azure-storage-common-src-common-internal-servicerestproxy-php.patch`
- Updated Dockerfile to copy `patches/` directory before `composer install` (required for patch to apply during build)
- Configured patch in `composer.json` extra section

## Review & Testing Checklist for Human

- [ ] **Test cross-stack migration (Azure → GCP) with `directDataMigration: false`** - This is the scenario that was failing. Use the runtime tag from CI to test before merging.
- [ ] Verify the patch is correctly applied during `composer install` (check CI logs for "Applying patches for microsoft/azure-storage-common")
- [ ] Confirm existing backup functionality still works (same-stack backups, structure-only exports)

### Notes

This patch is identical to the one in `app-project-restore`: https://github.com/keboola/app-project-restore/blob/master/patches/microsoft-azure-storage-common-src-common-internal-servicerestproxy-php.patch

**Link to Devin run:** https://app.devin.ai/sessions/95ac0c415d154b7c9aa70a3b778ec27b
**Requested by:** Jakub Sochan (@Jakuboola)
**Related:** [SUPPORT-14815](https://keboola.atlassian.net/browse/SUPPORT-14815), [job](https://connection.europe-west3.gcp.keboola.com/admin/projects/2580/queue/57488259) that encountred the error and [job](https://connection.europe-west3.gcp.keboola.com/admin/projects/2580/queue/57491981) with the tag that created the snapshot correctly.

## Release Notes
**Justification, description**

Fixes cross-stack migration from Azure stacks when using `directDataMigration: false` option.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Low risk - patch is already proven in app-project-restore

**Deployment Plan**

Standard deployment

**Rollback Plan**

Revert commit

**Post-Release Support Plan**

N/A

[SUPPORT-14815]: https://keboola.atlassian.net/browse/SUPPORT-14815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ