### PR TITLE
[AJDA-2577] Add architectural documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# app-project-backup – AI Development Context
+
+## What this repository does
+
+Keboola App component for backing up a project to cloud storage (S3, ABS, GCS). Wraps the `php-kbc-project-backup` library. Run by `app-project-migrate` as Phase 1 of the pipeline, but can also be run standalone – e.g. for periodic project backups.
+
+## Documentation
+
+- **`docs/overview.md`** – what is backed up, what is skipped, storage backends, parameters
+- **`docs/how-it-works.md`** – step-by-step backup flow (`Application::run`, `federationToken`, sliced vs non-sliced)
+- **`docs/configuration.md`** – complete input parameter reference for all 3 backends
+
+## Required environment variables
+
+Before running tests, verify that these variables are present in `.env` (or exported in the shell). If missing, ask for them explicitly.
+
+**For AWS S3 tests:**
+
+| Variable | Description |
+|---|---|
+| `TEST_STORAGE_API_URL` | URL of the Keboola project on AWS stack |
+| `TEST_STORAGE_API_TOKEN` | Storage token of the project on AWS stack |
+| `TEST_AWS_ACCESS_KEY_ID` | AWS Access Key ID |
+| `TEST_AWS_SECRET_ACCESS_KEY` | AWS Secret Access Key |
+| `TEST_AWS_REGION` | AWS region (e.g. `us-east-1`) |
+| `TEST_AWS_S3_BUCKET` | S3 bucket name for test backups |
+
+**For Azure ABS tests:**
+
+| Variable | Description |
+|---|---|
+| `TEST_AZURE_STORAGE_API_URL` | URL of the Keboola project on Azure stack |
+| `TEST_AZURE_STORAGE_API_TOKEN` | Storage token of the project on Azure stack |
+| `TEST_AZURE_ACCOUNT_NAME` | Azure storage account name |
+| `TEST_AZURE_ACCOUNT_KEY` | Azure storage key |
+| `TEST_AZURE_REGION` | Azure region |
+
+**For GCS tests:**
+
+| Variable | Description |
+|---|---|
+| `TEST_GCP_STORAGE_API_URL` | URL of the Keboola project on GCP stack |
+| `TEST_GCP_STORAGE_API_TOKEN` | Storage token of the project on GCP stack |
+| `TEST_GCP_BUCKET` | GCS bucket name for test backups |
+| `TEST_GCP_REGION` | GCP region |
+| `TEST_GCP_SERVICE_ACCOUNT` | JSON service account key (full JSON as string) |
+
+**Platform-injected (automatically set by Keboola Runner when running in Keboola):**
+
+| Variable | Description |
+|---|---|
+| `KBC_URL` | Keboola project URL (for production) |
+| `KBC_TOKEN` | Project storage token (for production) |
+| `KBC_RUNID` | Job run ID, set on the SAPI client |
+
+> Check that the `.env` file exists in the repo root. If not, create it based on the list above.
+
+## Development commands
+
+Service name in `docker-compose.yml` is `dev`.
+
+```bash
+docker compose run --rm dev composer phpcs
+docker compose run --rm dev composer phpstan
+docker compose run --rm dev composer tests
+docker compose run --rm dev composer build     # phplint + phpcs + phpstan + tests
+```
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `src/Component.php` | Entry point, action routing |
+| `src/Application.php` | Backup orchestration, calls storage backend |
+| `src/Config/Config.php` | Configuration getters |
+| `src/Config/ConfigDefinition.php` | Parameter validation |
+| `src/Config/S3Config.php` | AWS S3-specific configuration |
+| `src/Config/AbsConfig.php` | Azure Blob Storage-specific configuration |
+| `src/Config/GcsConfig.php` | Google Cloud Storage-specific configuration |
+| `src/Storages/` | Adapters for S3, ABS, GCS |
+
+## Sync action: generate-read-credentials
+
+Returns temporary read-only credentials for the backup location. Called by `app-project-migrate` after backup so the destination project can access storage without sharing long-lived credentials.
+
+## Coding standards
+
+- PHP 8.x with strict types
+- PHPStan level max
+- Keboola coding standard (PSR-12)
+
+## Related repositories
+
+- Library: `php-kbc-project-backup`
+- Orchestrator: `app-project-migrate`
+- Paired with: `app-project-restore`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,119 @@
+# Configuration parameter reference – app-project-backup
+
+## Required parameters
+
+| Parameter | Description |
+|---|---|
+| `storageBackendType` | Cloud storage type: `s3`, `abs`, or `gcs` |
+
+The backup path must be defined in exactly one of two ways:
+- `backupId` – an ID from which the path is assembled automatically
+- `backupPath` – custom full path in storage
+
+## General parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `exportStructureOnly` | `false` | If `true`, backs up only metadata (buckets, tables, configurations) without table data |
+| `includeVersions` | not set | If `true`, includes configuration version history |
+| `skipRegionValidation` | `false` | Skips validation that project region matches storage backend region |
+
+## S3 credentials
+
+Used if `storageBackendType: s3`.
+
+| Parameter | Required | Description |
+|---|---|---|
+| `access_key_id` | ✓ | AWS Access Key ID |
+| `#secret_access_key` | ✓ | AWS Secret Access Key |
+| `region` | ✓ | AWS region (e.g. `us-east-1`) |
+| `#bucket` | ✓ | S3 bucket name |
+| `backupId` or `backupPath` | ✓ | Backup path |
+
+## ABS credentials (Azure Blob Storage)
+
+Used if `storageBackendType: abs`.
+
+| Parameter | Required | Description |
+|---|---|---|
+| `accountName` | ✓ | Azure storage account name |
+| `#accountKey` | ✓ | Azure storage key |
+| `backupPath` | ✓ | Backup path (container/path) |
+
+## GCS credentials (Google Cloud Storage)
+
+Used if `storageBackendType: gcs`.
+
+| Parameter | Required | Description |
+|---|---|---|
+| `#jsonKey` | ✓ | JSON service account key (full JSON as string) |
+| `#bucket` | ✓ | GCS bucket name (encrypted) |
+| `region` | ✓ | GCP region (e.g. `europe-west3`) |
+| `backupId` or `backupPath` | ✓ | Backup path |
+
+> `projectId` is NOT an input parameter – it is extracted from `#jsonKey` (`jsonKey['project_id']`).
+
+## Sync action: generate-read-credentials
+
+This action is not called directly by users – it is called by `app-project-migrate` after backup. It returns temporary read-only credentials for the backup that are passed to `app-project-restore`.
+
+## Configuration examples
+
+### Backup to S3 (full)
+
+```json
+{
+  "parameters": {
+    "storageBackendType": "s3",
+    "backupId": "12345",
+    "access_key_id": "AKIA...",
+    "#secret_access_key": "secret",
+    "region": "us-east-1",
+    "#bucket": "my-kbc-backups",
+    "includeVersions": true
+  }
+}
+```
+
+### Backup to S3 (structure only, no table data)
+
+```json
+{
+  "parameters": {
+    "storageBackendType": "s3",
+    "backupId": "12345",
+    "access_key_id": "AKIA...",
+    "#secret_access_key": "secret",
+    "region": "us-east-1",
+    "#bucket": "my-kbc-backups",
+    "exportStructureOnly": true
+  }
+}
+```
+
+### Backup to GCS
+
+```json
+{
+  "parameters": {
+    "storageBackendType": "gcs",
+    "backupId": "12345",
+    "#jsonKey": "{\"type\":\"service_account\",\"project_id\":\"my-gcp-project\",...}",
+    "#bucket": "my-kbc-backups",
+    "region": "europe-west3"
+  }
+}
+```
+
+### Backup to ABS (Azure)
+
+```json
+{
+  "parameters": {
+    "storageBackendType": "abs",
+    "accountName": "mystorageaccount",
+    "#accountKey": "base64key==",
+    "backupPath": "my-container/backups/project-123"
+  }
+}
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,16 +6,17 @@
 |---|---|
 | `storageBackendType` | Cloud storage type: `s3`, `abs`, or `gcs` |
 
-The backup path must be defined in exactly one of two ways:
-- `backupId` – an ID from which the path is assembled automatically
-- `backupPath` – custom full path in storage
+The backup path depends on which credentials are used:
+
+- **Image parameter credentials** (injected by Keboola, no `storageBackendType` in `parameters`): path is auto-assembled as `data-takeout/<region>/<projectId>/<backupId>/`. `backupId` must be provided in `parameters`; in the `generate-read-credentials` action it is auto-generated if missing.
+- **User-defined credentials** (`storageBackendType` present in `parameters`): path comes from `backupPath`.
 
 ## General parameters
 
 | Parameter | Default | Description |
 |---|---|---|
 | `exportStructureOnly` | `false` | If `true`, backs up only metadata (buckets, tables, configurations) without table data |
-| `includeVersions` | not set | If `true`, includes configuration version history |
+| `includeVersions` | `false` | If `true`, includes configuration version history |
 | `skipRegionValidation` | `false` | Skips validation that project region matches storage backend region |
 
 ## S3 credentials
@@ -38,7 +39,7 @@ Used if `storageBackendType: abs`.
 |---|---|---|
 | `accountName` | ✓ | Azure storage account name |
 | `#accountKey` | ✓ | Azure storage key |
-| `backupPath` | ✓ | Backup path (container/path) |
+| `backupPath` | ✓ | Azure container name for the backup. Any `/` characters are replaced with `-` (e.g. `my-container/foo` becomes container `my-container-foo`). Nested prefixes inside a container are not supported. |
 
 ## GCS credentials (Google Cloud Storage)
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -22,15 +22,20 @@ Component.php
 
 ## Backup path
 
-If no custom credentials are defined (no `backupPath`), the path is auto-generated:
+Path selection is based on whether `parameters.storageBackendType` is set in the input config (`Config::isUserDefinedCredentials()`):
+
+- **User-defined credentials** (`storageBackendType` in `parameters`): `Application::run()` calls `Config::getPath()`, which returns `backupPath`.
+- **Image parameter credentials** (no `storageBackendType` in `parameters`): path is auto-generated as:
 
 ```
 data-takeout/<region>/<projectId>/<backupId>/
 ```
 
-- `region` and `projectId` are read from the SAPI `verifyToken()` response
-- `backupId` comes either from the configuration or is generated via `$sapi->generateId()`
-- The region from the token is also validated to match the region from the image parameters (can be disabled via `skipRegionValidation`)
+where `region` and `projectId` come from the SAPI `verifyToken()` response, and `backupId` is taken from `parameters.backupId` (cast to `int`; becomes `0` if not provided).
+
+> Note: `backupId` is auto-generated via `$sapi->generateId()` only in the `generate-read-credentials` action, not in `run`.
+
+The region is validated to match the region from the image parameters (can be disabled via `skipRegionValidation`).
 
 ## How tables are backed up
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,109 @@
+# app-project-backup – how the backup works
+
+## Call flow (Application::run)
+
+```
+Component.php
+  └─ Application::run()
+       1. initSapi()              – creates StorageApi client (KBC_URL + KBC_TOKEN)
+       2. generateBackupPath()    – data-takeout/<region>/<projectId>/<backupId>/
+          or getPath()            – if user-defined credentials are provided
+       3. storageBackend->getBackup()  – creates S3Backup / AbsBackup / GcsBackup
+       4. backup->backupProjectMetadata()
+       5. backup->backupTablesMetadata()
+       6. foreach tables:
+            backup->backupTable($tableId)
+       7. backup->backupConfigs()
+       8. backup->backupTriggers()
+       9. backup->backupNotifications()
+      10. backup->backupPermanentFiles()
+      11. (GCS + auto path only) backup->backupSignedUrls()
+```
+
+## Backup path
+
+If no custom credentials are defined (no `backupPath`), the path is auto-generated:
+
+```
+data-takeout/<region>/<projectId>/<backupId>/
+```
+
+- `region` and `projectId` are read from the SAPI `verifyToken()` response
+- `backupId` comes either from the configuration or is generated via `$sapi->generateId()`
+- The region from the token is also validated to match the region from the image parameters (can be disabled via `skipRegionValidation`)
+
+## How tables are backed up
+
+### Initialization
+
+At the start, `defaultBranch` is fetched via `DevBranches::listBranches()`. A `BranchAwareClient` is created for operations on the default branch (metadata, configurations).
+
+### backupTable – flow for a single table
+
+```
+getTableFileInfo($tableId)
+  ├─ getTable($tableId)           – loads table metadata
+  ├─ skip condition checks:
+  │    stage === 'sys'            → SkipTableException
+  │    hasExternalSchema          → SkipTableException
+  │    sourceBucket (DataCatalog) → SkipTableException
+  │    isAlias                    → SkipTableException
+  ├─ exportTableAsync($tableId, ['gzip' => true])
+  └─ getFile($fileId, federationToken: true)  → fileInfo with credentials
+
+getFileClient($fileInfo)
+  ├─ S3FileClient   – if credentials/absCredentials not in fileInfo
+  ├─ AbsFileClient  – if absCredentials is in fileInfo
+  └─ GcsFileClient  – if provider === 'gcp'
+
+if isSliced:
+  download manifest → foreach entries → putToStorage(table/name.part_N.csv.gz)
+else:
+  putToStorage(stage/c-bucket/table.csv.gz)
+```
+
+### FederationToken
+
+`getFile()` is called with `setFederationToken(true)`. The returned `fileInfo` contains temporary credentials (AWS STS, ABS SAS token, or GCS ADC token) for direct access to cloud storage without going through SAPI. This significantly speeds up the transfer of large tables.
+
+### Sliced vs. non-sliced
+
+| Type | Approach |
+|-----|--------|
+| Non-sliced | Single `table.csv.gz` file → direct download via FileClient |
+| Sliced | Manifest JSON → list of chunk URLs → each chunk separately via FileClient |
+
+## Sync action: generate-read-credentials
+
+`Application::generateReadCredentials()` returns temporary read-only credentials for the backup location:
+
+```
+initSapi()
+backupId = config.getBackupId() ?: sapi.generateId()
+path     = generateBackupPath() or getPath()
+return storageBackend->generateTempReadCredentials(backupId, path)
+```
+
+This action is called by `app-project-migrate` (Phase 2) so the destination project can access the backup without sharing long-lived credentials.
+
+## Backends – putToStorage
+
+Each backend implements the abstract `putToStorage(string $name, $content)`:
+
+| Backend | Implementation |
+|---------|-------------|
+| S3Backup | `S3Client::putObject(Bucket, Key, Body)` |
+| AbsBackup | `BlobRestProxy::createBlockBlob(container, name, content)` |
+| GcsBackup | `StorageObject::upload($content)` |
+
+## Configurations
+
+`backupConfigs()` iterates through all components with pagination (limit 2 per page, repeats while data exists). For each configuration it saves:
+- `configurations/<componentId>/<configId>.json` – data + rows + state
+- `configurations/<componentId>/<configId>.json.metadata` – configuration metadata
+
+Configuration versions are saved only if `includeVersions: true`.
+
+## GCS – backupSignedUrls
+
+Only for GCS backend without user-defined credentials. Saves `signedUrls.json` with a signed URL for each backup file. Used for alternative access to the backup without credentials.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,85 @@
+# app-project-backup – overview
+
+## What the component does
+
+Backs up a Keboola project to cloud storage (S3, Azure Blob Storage or GCS). This is a Keboola App component that wraps the `php-kbc-project-backup` library.
+
+Run by `app-project-migrate` as Phase 1 of the migration pipeline, but can also be run standalone – e.g. for periodic project backups.
+
+## What is backed up
+
+| Artifact | Path in storage |
+|---|---|
+| Default branch metadata | `defaultBranchMetadata.json` |
+| Bucket definitions | `buckets.json` |
+| Table definitions + column metadata | `tables.json` |
+| Table data (gzip CSV, non-sliced) | `<stage>/c-<bucket>/<table>.csv.gz` |
+| Table data (sliced) | `<stage>/c-<bucket>/<table>.part_N.csv.gz` |
+| Component index with configurations | `configurations.json` |
+| Component configurations | `configurations/<componentId>/<configId>.json` |
+| Configuration metadata | `configurations/<componentId>/<configId>.json.metadata` |
+| Configuration version history | part of config JSON (if `includeVersions: true`) |
+| Permanent files | `files/<fileId>` |
+| Permanent files metadata | `permanentFiles.json` |
+| Triggers | `triggers.json` |
+| Notifications (default branch only) | `notifications.json` |
+| GCS signed URLs | `signedUrls.json` (GCS backend only) |
+
+## What is skipped
+
+- **Sys bucket** tables
+- **Alias** tables (have no own data)
+- **External schema** tables
+- **Data Catalog** tables (have `sourceBucket` set)
+- Notifications not belonging to the default branch
+
+## Storage backends
+
+| Backend | Authentication |
+|---|---|
+| AWS S3 | `access_key_id` + `#secret_access_key` + `region` + `#bucket` |
+| Azure Blob Storage | `accountName` + `#accountKey` |
+| GCS | `#jsonKey` (JSON service account) + `#bucket` + `region` (projectId extracted from jsonKey) |
+
+The path in storage is assembled from `backupId` (auto-generated as `data-takeout/<region>/<projectId>/<backupId>/`) or from `backupPath` (custom path).
+
+## Sync action: `generate-read-credentials`
+
+Returns temporary read-only credentials for the backup location. Used by `app-project-migrate` so the destination project can access the backup without sharing long-lived credentials.
+
+## Architecture
+
+```
+Component.php
+  └─ Application.php
+       └─ php-kbc-project-backup (library)
+            ├─ S3Backup / AbsBackup / GcsBackup
+            └─ FileClient / S3FileClient / AbsFileClient / GcsFileClient
+```
+
+## Key files
+
+| File | Description |
+|---|---|
+| `src/Component.php` | Entry point, action routing |
+| `src/Application.php` | Backup orchestration, calls the correct storage backend |
+| `src/Config/Config.php` | Configuration getters |
+| `src/Config/ConfigDefinition.php` | Parameter validation |
+| `src/Config/S3Config.php` | AWS S3-specific configuration |
+| `src/Config/AbsConfig.php` | Azure Blob Storage-specific configuration |
+| `src/Config/GcsConfig.php` | Google Cloud Storage-specific configuration |
+| `src/Storages/` | Adapters for S3, ABS, GCS |
+
+## Development and testing
+
+```bash
+docker compose run --rm dev composer phpcs
+docker compose run --rm dev composer phpstan
+docker compose run --rm dev composer tests
+```
+
+## Related repositories
+
+- Library: `php-kbc-project-backup`
+- Uses it: `app-project-migrate` (Phase 1 + Phase 2 sync action)
+- Paired with: `app-project-restore`

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -41,7 +41,9 @@ Run by `app-project-migrate` as Phase 1 of the migration pipeline, but can also 
 | Azure Blob Storage | `accountName` + `#accountKey` |
 | GCS | `#jsonKey` (JSON service account) + `#bucket` + `region` (projectId extracted from jsonKey) |
 
-The path in storage is assembled from `backupId` (auto-generated as `data-takeout/<region>/<projectId>/<backupId>/`) or from `backupPath` (custom path).
+The storage path depends on which credentials are used:
+- **Image parameter credentials** (no `storageBackendType` in `parameters`): path is `data-takeout/<region>/<projectId>/<backupId>/`. `backupId` must be provided in `parameters` for the `run` action; in `generate-read-credentials` it is auto-generated if missing.
+- **User-defined credentials** (`storageBackendType` set in `parameters`): path comes from `backupPath`.
 
 ## Sync action: `generate-read-credentials`
 


### PR DESCRIPTION
Add CLAUDE.md with AI development context, required environment variables, key files and development commands. Add docs/ folder with overview, how-it-works and configuration documentation covering backup flow, federation tokens, sliced vs non-sliced handling and all three storage backends (S3, ABS, GCS).